### PR TITLE
fix: update fisherman's git clone branch to main

### DIFF
--- a/fisherman.bash
+++ b/fisherman.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 . ./prelude.sh
 
-github_clone edgeandnode/network-services master
+github_clone edgeandnode/network-services main
 cd build/edgeandnode/network-services
 cargo build
 cd -


### PR DESCRIPTION
Fisherman's repo (https://github.com/edgeandnode/network-services) default branch has been renamed from `master` to `main` causing the process to fail.

- [x] Updated the fisherman's bash script: clone `main` branch instead of `master`.