### PR TITLE
dev-overrides: switch indexer-agent to use tsx

### DIFF
--- a/indexer-agent/Dockerfile
+++ b/indexer-agent/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 RUN curl -L https://foundry.paradigm.xyz | bash && \
   /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
-RUN npm install -g ts-node nodemon prettier eslint
+RUN npm install -g tsx nodemon prettier eslint
 
 COPY ./run.sh /opt/run.sh
 ENTRYPOINT bash -cl /opt/run.sh

--- a/overrides/indexer-agent-dev/run-override.sh
+++ b/overrides/indexer-agent-dev/run-override.sh
@@ -78,14 +78,13 @@ cat ./config/config.yaml
 echo "Current PWD $PWD"
 
 nodemon --watch . \
---ext js \
+--ext ts \
 --legacy-watch \
 --delay 4 \
 --verbose \
 --exec "
 NODE_OPTIONS=\"--inspect=0.0.0.0:9230\"
-ts-node \
-  packages/indexer-agent/src/index.ts start
+tsx packages/indexer-agent/src/index.ts start"
 
 # TODO: port this script to use a config file...
 # --network-specifications-directory /opt/network-configs/"


### PR DESCRIPTION
Needed after indexer-agent started consuming ESM modules.