### PR TITLE
fix(subgraph-deploy): pin indexer-cli to v0.22

### DIFF
--- a/subgraph-deploy/Dockerfile
+++ b/subgraph-deploy/Dockerfile
@@ -2,7 +2,9 @@ FROM --platform=linux/amd64 debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y curl jq nodejs npm \
     && rm -rf /var/lib/apt/lists/*
-RUN npm install --global @graphprotocol/indexer-cli
+
+RUN npm install --global @graphprotocol/indexer-cli@~0.22.0  # >=0.22.0,<0.23.0
+
 RUN curl -L https://foundry.paradigm.xyz | bash && /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
 
 COPY ./run.sh /opt/run.sh


### PR DESCRIPTION
This pull request includes an update to the `subgraph-deploy/Dockerfile` to ensure compatibility and stability by specifying a version range for the `indexer-cli` package.

Version specification for dependencies:

* [`subgraph-deploy/Dockerfile`](diffhunk://#diff-e561760a9763e91f6f20bb313f4d105dd32585ada00d51c97191a8f4142efb4aL5-R7): Changed the `npm install --global @graphprotocol/indexer-cli` command to specify the version range `~0.22.0`, ensuring the installed version is greater than or equal to 0.22.0 and less than 0.23.0.