### PR TITLE
feat: copy foundry from container image

### DIFF
--- a/block-oracle/Dockerfile
+++ b/block-oracle/Dockerfile
@@ -10,9 +10,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get install -y nodejs && \
   npm install --global corepack yarn
 
-# Install Foundry (pinned nightly version)
-RUN curl -L https://foundry.paradigm.xyz | bash && \
-  /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
+# Install Foundry
+COPY --from=ghcr.io/foundry-rs/foundry:nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59 \
+  /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/chisel /usr/local/bin/
 
 # Install Rust toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal

--- a/indexer-agent/Dockerfile
+++ b/indexer-agent/Dockerfile
@@ -2,8 +2,11 @@ FROM --platform=linux/amd64 ghcr.io/graphprotocol/indexer-agent:v0.22.0
 RUN apt-get update \
     && apt-get install -y jq \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -L https://foundry.paradigm.xyz | bash && \
-    /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
+
+# Install Foundry
+COPY --from=ghcr.io/foundry-rs/foundry:nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59 \
+  /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/chisel /usr/local/bin/
+
 RUN npm install -g tsx nodemon prettier eslint
 
 COPY ./run.sh /opt/run.sh

--- a/subgraph-deploy/Dockerfile
+++ b/subgraph-deploy/Dockerfile
@@ -3,9 +3,13 @@ RUN apt-get update \
     && apt-get install -y curl jq nodejs npm \
     && rm -rf /var/lib/apt/lists/*
 
+# Indexer CLI
 RUN npm install --global @graphprotocol/indexer-cli@~0.22.0  # >=0.22.0,<0.23.0
 
-RUN curl -L https://foundry.paradigm.xyz | bash && /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
+# Foundry
+COPY --from=ghcr.io/foundry-rs/foundry:nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59 \
+  /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/chisel /usr/local/bin/
 
 COPY ./run.sh /opt/run.sh
+
 ENTRYPOINT bash -cl /opt/run.sh

--- a/tap-contracts/Dockerfile
+++ b/tap-contracts/Dockerfile
@@ -3,14 +3,17 @@ RUN apt-get update \
   && apt-get install -y curl git jq nodejs npm \
   && rm -rf /var/lib/apt/lists/*
 RUN npm install --global yarn
-RUN curl -L https://foundry.paradigm.xyz | bash && \
-  /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
-RUN curl https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -L -o /usr/bin/yq && \
+
+# Install Foundry
+COPY --from=ghcr.io/foundry-rs/foundry:nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59 \
+  /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/chisel /usr/local/bin/
+
+  RUN curl https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -L -o /usr/bin/yq && \
   chmod +x /usr/bin/yq
 
 WORKDIR /opt
 RUN git clone https://github.com/semiotic-ai/timeline-aggregation-protocol-contracts --branch 'main' && \
-  cd timeline-aggregation-protocol-contracts && yarn && /root/.foundry/bin/forge build
+  cd timeline-aggregation-protocol-contracts && yarn && forge build
 RUN git clone https://github.com/semiotic-ai/timeline-aggregation-protocol-subgraph --branch 'main' --recursive && \
   cd timeline-aggregation-protocol-subgraph && yarn
 

--- a/tap-escrow-manager/Dockerfile
+++ b/tap-escrow-manager/Dockerfile
@@ -3,8 +3,11 @@ RUN apt-get update \
     && apt-get install -y clang cmake curl git jq libsasl2-dev libssl-dev pkg-config zip \
     && rm -rf /var/lib/apt/lists/*
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
-RUN curl -L https://foundry.paradigm.xyz | bash && \
-    /root/.foundry/bin/foundryup --install nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59
+
+# Install Foundry
+COPY --from=ghcr.io/foundry-rs/foundry:nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59 \
+  /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/chisel /usr/local/bin/
+
 RUN curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip && unzip rpk-linux-amd64.zip -d /usr/local/bin/
 
 WORKDIR /opt


### PR DESCRIPTION
This pull request includes changes to multiple Dockerfiles to improve the installation method for Foundry by using pre-built binaries instead of downloading and installing them from the source.

* Replaced the Foundry installation from the source by copying pre-built binaries from `ghcr.io/foundry-rs/foundry:nightly-0e519ffde8ab5babde7dffa96fca28cfa3608b59` container image.
