### PR TITLE
fix: FromPlatformFlagConstDisallowed build warning

### DIFF
--- a/indexer-agent/Dockerfile
+++ b/indexer-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/graphprotocol/indexer-agent:v0.22.0
+FROM ghcr.io/graphprotocol/indexer-agent:v0.22.0
 RUN apt-get update \
     && apt-get install -y jq \
     && rm -rf /var/lib/apt/lists/*

--- a/subgraph-deploy/Dockerfile
+++ b/subgraph-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 debian:bookworm-slim
+FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y curl jq nodejs npm \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request includes changes to the Dockerfiles for `indexer-agent` and `subgraph-deploy` to simplify the base image specification.

Changes to Dockerfiles:

* [`indexer-agent/Dockerfile`](diffhunk://#diff-5f953c6cfd28c5efb00c131d78d78719bf528bad8ee9d65e058bcac8ab3980ccL1-R1): Removed the `--platform=linux/amd64` option from the `FROM` statement.
* [`subgraph-deploy/Dockerfile`](diffhunk://#diff-e561760a9763e91f6f20bb313f4d105dd32585ada00d51c97191a8f4142efb4aL1-R1): Removed the `--platform=linux/amd64` option from the `FROM` statement.

This fixes the `FromPlatformFlagConstDisallowed` build warning.