### PR TITLE
chore: add tap-escrow-manager as a gateway runtime dependency

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,6 +176,7 @@ services:
       subgraph-deploy: { condition: service_completed_successfully }
       indexer-service: { condition: service_healthy }
       redpanda: { condition: service_healthy }
+      tap-escrow-manager: { condition: service_started }
     ports: ["${GATEWAY}:7700"]
     stop_signal: SIGKILL
     volumes:


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yaml` file. The change adds a new service called `tap-escrow-manager` with a condition to start the service when it is started.

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R179): Added `tap-escrow-manager` service with `condition: service_started`.