### PR TITLE
chore: update IPFS image to v0.34.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,10 +9,12 @@ services:
 
   ipfs:
     container_name: ipfs
-    image: ipfs/kubo:v0.27.0
+    image: ipfs/kubo:v0.34.1
     ports: ["${IPFS_RPC}:5001"]
+    environment:
+      IPFS_PROFILE: server
     healthcheck: 
-      { interval: 1s, retries: 10, test: ipfs id }
+      { interval: 1s, retries: 50, test: ipfs id }
 
   postgres:
     container_name: postgres


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.yaml` file for the IPFS service. The most significant changes involve updating the IPFS image version, adding an environment variable, and modifying the health check configuration.

* Updated the IPFS image version from `v0.27.0` to `v0.34.1`.
* Added the `IPFS_PROFILE` environment variable with the value `server`.
* Modified the health check configuration to increase the number of retries from 10 to 50.