### PR TITLE
fix: reliability fixes for local-network startup

### DIFF
--- a/containers/core/subgraph-deploy/run.sh
+++ b/containers/core/subgraph-deploy/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
+# shellcheck source=/dev/null
 . /opt/config/.env
+# shellcheck source=/dev/null
 . /opt/shared/lib.sh
 
 t0=$SECONDS

--- a/containers/core/subgraph-deploy/run.sh
+++ b/containers/core/subgraph-deploy/run.sh
@@ -32,7 +32,11 @@ deploy_network() {
   npx mustache ./config/generatedAddresses.json subgraph.template.yaml > subgraph.yaml
   npx graph codegen --output-dir src/types/
   npx graph create graph-network --node="http://graph-node:${GRAPH_NODE_ADMIN_PORT}"
-  npx graph deploy graph-network --node="http://graph-node:${GRAPH_NODE_ADMIN_PORT}" --ipfs="http://ipfs:${IPFS_RPC_PORT}" --version-label=v0.0.1
+  npx graph deploy graph-network --node="http://graph-node:${GRAPH_NODE_ADMIN_PORT}" --ipfs="http://ipfs:${IPFS_RPC_PORT}" --version-label=v0.0.1 | tee deploy.txt
+  deployment_id="$(grep "Build completed: " deploy.txt | awk '{print $3}' | sed -e 's/\x1b\[[0-9;]*m//g')"
+  curl -s "http://graph-node:${GRAPH_NODE_ADMIN_PORT}" \
+    -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"subgraph_reassign\",\"params\":{\"node_id\":\"default\",\"ipfs_hash\":\"${deployment_id}\"}}"
   echo "==== Network subgraph done ===="
 }
 

--- a/containers/indexer/start-indexing/run.sh
+++ b/containers/indexer/start-indexing/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
+# shellcheck source=/dev/null
 . /opt/config/.env
+# shellcheck source=/dev/null
 . /opt/shared/lib.sh
 
 t0=$SECONDS


### PR DESCRIPTION
## TL;DR

The local-network stack occasionally comes up with the network subgraph stuck in an unassigned state, blocking indexer-service and gateway from reading network data. This PR adds the missing `subgraph_reassign` call to `deploy_network`, mirroring the pattern used by the other three subgraph deploys. Plus a small shellcheck cleanup on the two run.sh files this PR touches.

## Motivation

Three subgraphs deploy in parallel during stack startup: network, TAP, and block-oracle. Two of them — TAP and block-oracle — call `subgraph_reassign` on graph-node's admin API afterwards, because graph-cli occasionally leaves a deployed subgraph unassigned and graph-node never starts indexing it. The network subgraph deploy is the only one that skips this step, so when the race fires there, indexer-service and gateway wait on queries that never resolve and the stack is silently broken at the data layer.

## Summary

- Add `subgraph_reassign` to `deploy_network`, matching the pattern used by the other deploys
- Silence shellcheck SC1091 warnings in the two `run.sh` files this PR touches