### PR TITLE
feat: add gateway dev override

### DIFF
--- a/compose/dev/README.md
+++ b/compose/dev/README.md
@@ -28,6 +28,7 @@ Then `just up` applies the overrides automatically.
 | `indexer-agent.yaml`      | indexer-agent                    | `INDEXER_AGENT_SOURCE_ROOT`                            |
 | `indexer-service.yaml`    | indexer-service                  | `INDEXER_SERVICE_BINARY`                               |
 | `tap-agent.yaml`          | tap-agent                        | `TAP_AGENT_BINARY`                                     |
+| `gateway.yaml`            | gateway                          | `GATEWAY_BINARY`                                       |
 | `eligibility-oracle.yaml` | eligibility-oracle-node          | `REO_BINARY`                                           |
 | `dipper.yaml`             | dipper                           | `DIPPER_BINARY`                                        |
 | `iisa.yaml`               | iisa                             | `IISA_VERSION=local`                                   |

--- a/compose/dev/gateway.yaml
+++ b/compose/dev/gateway.yaml
@@ -1,0 +1,25 @@
+# Gateway Dev Override
+# Mounts a locally-built binary for WIP development (skip image rebuild).
+#
+# 1. One-time: build the build-env stage as a tagged image (from local-network root):
+#      docker build --target build-env --platform linux/arm64 \
+#        -t local-network-gateway-builder \
+#        containers/core/gateway/
+#
+# 2. Compile your local gateway source against it (from your gateway repo):
+#      docker run --rm --platform linux/arm64 \
+#        -v "$PWD:/work" \
+#        -v "$HOME/.cargo/registry:/usr/local/cargo/registry" \
+#        -w /work \
+#        local-network-gateway-builder \
+#        cargo build --target aarch64-unknown-linux-gnu -p graph-gateway
+#    Binary at: <gateway-repo>/target/aarch64-unknown-linux-gnu/debug/graph-gateway
+#
+# 3. Wire it in via .env (or .env.local, when using `just`):
+#      GATEWAY_BINARY=/path/to/gateway/target/aarch64-unknown-linux-gnu/debug/graph-gateway
+#      COMPOSE_FILE=docker-compose.yaml:compose/dev/gateway.yaml
+
+services:
+  gateway:
+    volumes:
+      - ${GATEWAY_BINARY:?Set GATEWAY_BINARY to locally-built graph-gateway binary}:/usr/local/bin/graph-gateway:ro

--- a/containers/core/gateway/Dockerfile
+++ b/containers/core/gateway/Dockerfile
@@ -1,15 +1,24 @@
-FROM debian:bookworm-slim
-ARG GATEWAY_COMMIT
-
+# Stage 1: build environment — deps only, reusable as a dev builder
+FROM rust:1-slim-bookworm AS build-env
 RUN apt-get update \
-    && apt-get install -y clang cmake curl git jq libsasl2-dev libssl-dev pkg-config protobuf-compiler \
+    && apt-get install -y clang cmake git libsasl2-dev libssl-dev pkg-config protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 
+# Stage 2: build the pinned gateway commit
+FROM build-env AS build
+ARG GATEWAY_COMMIT
 WORKDIR /opt
 RUN git clone https://github.com/edgeandnode/gateway && \
     cd gateway && git checkout ${GATEWAY_COMMIT} && \
-    . /root/.cargo/env && cargo build -p graph-gateway && \
-    cp target/debug/graph-gateway /usr/local/bin/graph-gateway && cd .. && rm -rf gateway
+    cargo build -p graph-gateway && \
+    cp target/debug/graph-gateway /usr/local/bin/graph-gateway
+
+# Stage 3: minimal runtime
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y curl jq libsasl2-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt
+COPY --from=build /usr/local/bin/graph-gateway /usr/local/bin/graph-gateway
 COPY ./run.sh /opt/run.sh
 ENTRYPOINT ["bash", "/opt/run.sh"]


### PR DESCRIPTION
 ## Changes

  - **New `compose/dev/gateway.yaml`** — mounts a locally-built `graph-gateway` binary into the gateway container. Same pattern as the existing `indexer-service.yaml` / `tap-agent.yaml` overrides.
  - **Refactored `containers/core/gateway/Dockerfile` to multi-stage** (`build-env` / `build` / runtime). `build-env` doubles as  the builder image for the dev override; the runtime stage drops the rust toolchain (~1.5GB → ~200MB).
